### PR TITLE
Add serverless-offline capability

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ class ServerlessPlugin {
 
     this.hooks = {
       'before:package:initialize': this.getVaultSecrets.bind(this),
+      'before:offline:start:init': this.getVaultSecrets.bind(this),
       'before:vault:vault': this.getVaultSecrets.bind(this), // Shows encrypted passwords from vault and kms
     };
     this.kms = new aws.KMS({region: this.options.region});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "serverless-vault-plugin",
   "description": "Serverless plugin for retrieve secrets from vault and input on kms",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "dependencies": {
     "aws-sdk": "2.313.0",
     "js-yaml": ">=3.13.1",

--- a/test/test.js
+++ b/test/test.js
@@ -33,7 +33,7 @@ describe ('Testing retrieving data from vault', () => {
   const commands = Object.keys(app.commands);
   
   it('Checking configs', () => {
-    expect(hooks).to.eql(['before:package:initialize', 'before:vault:vault']);
+    expect(hooks).to.eql(['before:package:initialize', 'before:offline:start:init', 'before:vault:vault']);
     
   });
 


### PR DESCRIPTION
Great plugin, would like to offer the option to add offline capabilities so we can test more easily when developing.

This allows the plugin to run when using the `serverless-offline` plugin. For example:

1. Run the offline plugin:
```
serverless offline start
```

2. invoke the lambda

```
aws lambda invoke /dev/null --endpoint-url http://localhost:3002 --function-name your-lambda-function-name
```